### PR TITLE
Fix build deps for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -38,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "numpy>=1.21"
+  "numpy>=1.26"
 ]
 
 [project.optional-dependencies]
@@ -57,10 +59,10 @@ repository = "https://github.com/ibarrond/github"
 # Minimum requirements for the build system to execute.
 [build-system]
 requires = [
-  "setuptools<=60.9",
+  "setuptools>=64",
   "wheel",
   "cython>=3.0.0",
-  "numpy>=1.21",
+  "numpy>=1.26",
   "cmake>=3.15",
   "toml>=0.10"
 ]


### PR DESCRIPTION
## Summary
- support Python 3.12
- loosen setuptools pin and update numpy version
- declare support for Python 3.11 and 3.12 in package metadata

## Testing
- `python3.12 -m compileall -q Pyfhel`
- `python3.12 -m pip install --no-build-isolation .` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_685c7caa867883289b471120f2033b7f